### PR TITLE
Laravel 5.7 compatibility changes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,10 +18,10 @@
   "license": "MIT",
   "require": {
     "php": ">=7.1.0",
-    "illuminate/support": "5.6.*",
-    "illuminate/console": "5.6.*",
-    "illuminate/database": "5.6.*",
-    "illuminate/filesystem": "5.6.*"
+    "illuminate/support": "5.7.*",
+    "illuminate/console": "5.7.*",
+    "illuminate/database": "5.7.*",
+    "illuminate/filesystem": "5.7.*"
   },
   "require-dev": {
     "mockery/mockery": "^1.1",

--- a/src/LaravelSeeder/Command/SeedReset.php
+++ b/src/LaravelSeeder/Command/SeedReset.php
@@ -39,13 +39,6 @@ class SeedReset extends AbstractSeedMigratorCommand
         $this->info('Removing seeded data for '.ucfirst($this->getEnvironment()).' environment...');
         $this->migrator->reset($this->getMigrationPaths(), $this->getMigrationOptions());
 
-        // Once the migrator has run we will grab the note output and send it out to
-        // the console screen, since the migrator itself functions without having
-        // any instances of the OutputInterface contract passed into the class.
-        foreach ($this->migrator->getNotes() as $note) {
-            $this->output->writeln($note);
-        }
-
         $this->info('Removed seeded data for '.ucfirst($this->getEnvironment()).' environment');
     }
 

--- a/src/LaravelSeeder/Command/SeedRollback.php
+++ b/src/LaravelSeeder/Command/SeedRollback.php
@@ -39,13 +39,6 @@ class SeedRollback extends AbstractSeedMigratorCommand
         $this->info('Rolling back seeded data for '.ucfirst($this->getEnvironment()).' environment...');
         $this->migrator->rollback($this->getMigrationPaths(), $this->getMigrationOptions());
 
-        // Once the migrator has run we will grab the note output and send it out to
-        // the console screen, since the migrator itself functions without having
-        // any instances of the OutputInterface contract passed into the class.
-        foreach ($this->migrator->getNotes() as $note) {
-            $this->output->writeln($note);
-        }
-
         $this->info('Rolled back seeded data for '.ucfirst($this->getEnvironment()).' environment');
     }
 

--- a/src/LaravelSeeder/Command/SeedRun.php
+++ b/src/LaravelSeeder/Command/SeedRun.php
@@ -39,13 +39,6 @@ class SeedRun extends AbstractSeedMigratorCommand
         $this->info('Seeding data for '.ucfirst($this->getEnvironment()).' environment...');
         $this->migrator->run($this->getMigrationPaths(), $this->getMigrationOptions());
 
-        // Once the migrator has run we will grab the note output and send it out to
-        // the console screen, since the migrator itself functions without having
-        // any instances of the OutputInterface contract passed into the class.
-        foreach ($this->migrator->getNotes() as $note) {
-            $this->output->writeln($note);
-        }
-
         $this->info('Seeded data for '.ucfirst($this->getEnvironment()).' environment');
     }
 

--- a/src/LaravelSeeder/Migration/SeederMigrationCreator.php
+++ b/src/LaravelSeeder/Migration/SeederMigrationCreator.php
@@ -40,7 +40,7 @@ class SeederMigrationCreator extends MigrationCreator
         // Next, we will fire any hooks that are supposed to fire after a migration is
         // created. Once that is done we'll be ready to return the full path to the
         // migration file so it can be used however it's needed by the developer.
-        $this->firePostCreateHooks();
+        $this->firePostCreateHooks($table);
 
         return $path;
     }

--- a/src/LaravelSeeder/Migration/SeederMigrator.php
+++ b/src/LaravelSeeder/Migration/SeederMigrator.php
@@ -39,13 +39,6 @@ class SeederMigrator extends Migrator implements SeederMigratorInterface
     protected $connection;
 
     /**
-     * The notes for the current operation.
-     *
-     * @var array
-     */
-    protected $notes = [];
-
-    /**
      * The paths to all of the migration files.
      *
      * @var array

--- a/src/LaravelSeeder/Migration/SeederMigratorInterface.php
+++ b/src/LaravelSeeder/Migration/SeederMigratorInterface.php
@@ -75,13 +75,6 @@ interface SeederMigratorInterface
     public function resolve($file): MigratableSeeder;
 
     /**
-     * Get the notes for the last operation.
-     *
-     * @return array
-     */
-    public function getNotes();
-
-    /**
      * Set the default connection name.
      *
      * @param string $name


### PR DESCRIPTION
Removed notes array from SeederMigrator 
Removed getNotes method from SeederMigratorInterface 
Changes for compatibility with Laravel 5.7 Illuminate\Database\Migrations\Migrator class 