### PR TITLE
Fix for SeederMigrationCreator instantiation bug in Laravel 7

### DIFF
--- a/src/LaravelSeeder/SeederServiceProvider.php
+++ b/src/LaravelSeeder/SeederServiceProvider.php
@@ -90,7 +90,7 @@ class SeederServiceProvider extends ServiceProvider
         });
 
         $this->app->singleton(SeederMigrationCreator::class, function ($app) {
-            return new SeederMigrationCreator($app['files']);
+            return new SeederMigrationCreator($app['files'], $app->basePath('stubs'));
         });
     }
 


### PR DESCRIPTION
Modified instantiation of `SeederMigrationCreator` to have the correct number of arguments.
It is now matching the creation of `MigrationCreator` in `MigrationServiceProvider`